### PR TITLE
Get setState working with on(authenticated) code

### DIFF
--- a/client/src/auth/Lock.js
+++ b/client/src/auth/Lock.js
@@ -35,7 +35,7 @@ class Lock extends Component {
         // this.getUserInfo = this.getUserInfo.bind(this);
 
         this.onAuthenticated();
-        this.getUserInfo();
+        //this.getUserInfo();
     }
 
     // onAuthenticated() {
@@ -46,20 +46,20 @@ class Lock extends Component {
             localStorage.setItem('id_token', authResult.idToken);
             localStorage.setItem('expires_at', expiresAt);
 
-            this.lock.getUserInfo(authResult.accessToken, function (error, profile) {
+            this.lock.getUserInfo(authResult.accessToken, (error, profile) => {
                 if (!error) {
                     localStorage.setItem("profile", JSON.stringify(profile));
 
-                    // this.setState({
-                    //     loggedIn: true,
-                    //     profile: JSON.stringify(profile)
-                    // })
+                    this.setState({
+                        loggedIn: true,
+                        profile: JSON.stringify(profile)
+                    })
                 };
             });
 
-            this.setState({ 
-                loggedIn: true 
-            });
+            // this.setState({ 
+            //     loggedIn: true 
+            // });
         });
     }
 


### PR DESCRIPTION
I think these changes get the code to work:

- The error with "setState of undefined" (missing `this` context) was actually being triggered by the call to this.getUserInfo() in the constructor. Commented that out.
- Changed the syntax callback passed to this.lock.getUserInfo() from conventional function to arrow function
- Only doing setState once: when both the authentication is obtained AND the user profile data is obtained. This way you're not calling setState when the component is unmounted (ie Lock is removed from the DOM because the user is logged in)